### PR TITLE
Make it possible to use email from form as email sender

### DIFF
--- a/modules/formmaker/functioncollection.php
+++ b/modules/formmaker/functioncollection.php
@@ -435,7 +435,7 @@ class FormMakerFunctionCollection
     */
     private function removeSessionData()
     {
-        foreach ( $_SESSION['_ezpubllish'] as $key => $value )
+        foreach ( $_SESSION['_ezpublish'] as $key => $value )
         {
             if ( !preg_match( '/^' . formDefinitions::PAGE_SESSION_PREFIX . '/', $key ) )
             {

--- a/modules/formmaker/functioncollection.php
+++ b/modules/formmaker/functioncollection.php
@@ -432,7 +432,7 @@ class FormMakerFunctionCollection
 
     /**
      * Method removes form session data
-     */
+    */
     private function removeSessionData()
     {
         foreach ( $_SESSION['_ezpubllish'] as $key => $value )
@@ -442,7 +442,7 @@ class FormMakerFunctionCollection
                 continue;
             }
             // clean up the session
-            unset( $_SESSION[$key] );
+            unset( $_SESSION['_ezpubllish'][$key] );
         }
     }
 

--- a/modules/formmaker/functioncollection.php
+++ b/modules/formmaker/functioncollection.php
@@ -339,7 +339,16 @@ class FormMakerFunctionCollection
             return false;
         }
 
-        $sender = eZINI::instance( 'site.ini' )->variable( 'MailSettings', 'EmailSender' );
+          $email_sender = eZINI::instance( 'site.ini' )->variable( 'MailSettings', 'FormmakerPleaseUseEmailSenderFromForm' );
+        if ($email_sender != null && $email_sender == "enabled") {
+            $fle = eZINI::instance( 'site.ini' )->variable( 'MailSettings', 'FormmakerLocationOfEmailAttribute' );
+            $sender = $email_data[$fle[0]][$fle[1]][$fle[2]][$fle[3]];
+            eZLog::write('Uses email_sender ' . $sender . ' from form' ,'formmaker.log');
+        } else {
+            $sender = eZINI::instance( 'site.ini' )->variable( 'MailSettings', 'EmailSender' );
+            eZLog::write('Uses standard email_sender ' . $sender .  ' from settingsfile' ,'formmaker.log');
+        }
+
         switch ( $this->ini->variable( 'Mail', 'MailClass' ) )
         {
             case 'eZMail':


### PR DESCRIPTION
    I want it to be able to use the email that the user has filled in as the email sender
    
    This requires the following in the site.ini.append.php file
    FormmakerPleaseUseEmailSenderFromForm=enabled
    FormmakerLocationOfEmailAttribute[]=0
    FormmakerLocationOfEmailAttribute[]=attributes
    FormmakerLocationOfEmailAttribute[]=2
    FormmakerLocationOfEmailAttribute[]=value
    
    You guys will probably find a better way of doing this :-)